### PR TITLE
bug_fix/crash when empty parameter exists

### DIFF
--- a/Src/Param.c
+++ b/Src/Param.c
@@ -89,7 +89,9 @@ Param* Param_next(Param_Cursor* cursor, Param* param) {
         cursor->Len = 0;
     }
     // trim right
-    paramStr = Str_trimRight(paramStr);
+    if(*paramStr){
+        paramStr = Str_trimRight(paramStr);
+    }
     // find value type base on first character
     switch (*paramStr) {
     #if PARAM_TYPE_NUMBER


### PR DESCRIPTION
I was trying to create a light library for nmea sentence based on the param library, but I noticed that when there are empty fields in a sentence; Like:
```
"$GPGGA,,,,,,1,10,1.2,27.0,M,-34.2,M,0,0000*5E"
```
The param library crashes.
And when I checked, I realized that the crash happens in the "Str_trimRight" step.
That's why I made these changes.